### PR TITLE
Golang change to external go list

### DIFF
--- a/deplist.go
+++ b/deplist.go
@@ -97,22 +97,13 @@ func GetDeps(fullPath string) ([]Dependency, Bitmask, error) {
 					foundTypes.DepFoundAddFlag(LangGolang)
 				}
 
-				for _, p := range pkgs {
+				for path, goPkg := range pkgs {
+
 					d := Dependency{
 						DepType: LangGolang,
-						Path:    p.PkgPath,
-						Files:   p.GoFiles,
-					}
-					if p.Module != nil {
-						d.Version = p.Module.Version
-						/* if replace is specified, then use that version
-						 * version only may exist here too
-						 * not seen when version and replace.version are differnt
-						 * but just in case
-						 */
-						if p.Module.Replace != nil {
-							d.Version = p.Module.Replace.Version
-						}
+						Path:    path,
+						Files:   goPkg.Gofiles,
+						Version: goPkg.Version,
 					}
 					deps = append(deps, d)
 				}

--- a/internal/scan/golang.go
+++ b/internal/scan/golang.go
@@ -38,7 +38,6 @@ const defaultOptions = packages.NeedDeps |
 
 func getVersion(deps GoListDeps) string {
 	/* if replace is specified, then use that version
-	* version only may exist here too
 	* not seen when version and replace.version are differnt
 	* but just in case
 	 */
@@ -93,6 +92,7 @@ func runGoList(path string) ([]byte, error) {
 }
 
 func GetGolangDeps(path string) (map[string]GoPkg, error) {
+	// need to use a map as we'll get lots of duplicate entries
 	gathered := make(map[string]GoPkg)
 
 	out, err := runGoList(path)

--- a/internal/scan/golang.go
+++ b/internal/scan/golang.go
@@ -64,7 +64,7 @@ func runCmd(path string, mod bool) ([]byte, error) {
 	out, err := cmd.Output()
 
 	if ctx.Err() == context.DeadlineExceeded {
-		return nil, errors.New("go list timeout")
+		return nil, ctx.Err()
 	}
 
 	if err != nil {

--- a/internal/scan/golang.go
+++ b/internal/scan/golang.go
@@ -1,12 +1,34 @@
 package scan
 
 import (
-	"os"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"os/exec"
 	"path/filepath"
-	"sort"
+	"strings"
+	"time"
 
+	"golang.org/x/mod/semver"
 	"golang.org/x/tools/go/packages"
 )
+
+type GoListDeps struct {
+	ImportPath string `json:"ImportPath"`
+	Module     struct {
+		Version string `json:"Version"`
+		Replace struct {
+			Version string `json:"Version"`
+		} `json:"Replace"`
+	} `json:"Module"`
+	GoFiles []string `json:"GoFiles"`
+}
+
+type GoPkg struct {
+	Version string
+	Gofiles []string
+}
 
 const defaultOptions = packages.NeedDeps |
 	packages.NeedImports |
@@ -14,49 +36,101 @@ const defaultOptions = packages.NeedDeps |
 	packages.NeedFiles |
 	packages.NeedName
 
-func GetGolangDeps(path string) ([]*packages.Package, error) {
-	dirPath := filepath.Dir(path) // force directory
+func getVersion(deps GoListDeps) string {
+	/* if replace is specified, then use that version
+	* version only may exist here too
+	* not seen when version and replace.version are differnt
+	* but just in case
+	 */
+	if deps.Module.Replace.Version != "" {
+		// due to the way we're loading the json this time, this just works
+		return deps.Module.Replace.Version
+	}
+	return deps.Module.Version
+}
 
-	cfg := packages.Config{Mode: defaultOptions, Dir: dirPath}
+func runCmd(path string, mod bool) ([]byte, error) {
+	// go list -f '{{if not .Standard}}{{.Module}}{{end}}' -json -deps ./...
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
 
-	pkgs, err := packages.Load(&cfg, "./...")
+	modVendor := ""
+	if mod {
+		modVendor = "-mod=vendor"
+	}
+	// go list -f '{{if not .Standard}}{{.Module}}{{end}}' -json -deps ./...
+	cmd := exec.CommandContext(ctx, "go", "list", modVendor, "-f", "'{{if not .Standard}}{{.Module}}{{end}}'", "-json", "-deps", "./...")
+	cmd.Dir = filepath.Dir(path) // // force directory
+	out, err := cmd.Output()
+
+	if ctx.Err() == context.DeadlineExceeded {
+		return nil, errors.New("go list timeout")
+	}
 
 	if err != nil {
-		cfg.Env = append(os.Environ(), "GOFLAGS=-mod=vendor")
-		pkgs, err = packages.Load(&cfg, "./...")
+		// assume some retrival error, we have to redo the cmd with mod=vendor
+		return nil, err
+	}
+
+	return out, nil
+}
+
+/*
+* Need to support re-running the go list with and without -mod=vendor
+* First run defaults to without, if any kind of error we'll just retry the run
+ */
+func runGoList(path string) ([]byte, error) {
+	out, err := runCmd(path, false)
+	if err != nil {
+		// rerun
+		out, err = runCmd(path, true)
+		if err != nil {
+			return nil, errors.New("error running go list")
+		}
+	}
+
+	return out, nil
+}
+
+func GetGolangDeps(path string) (map[string]GoPkg, error) {
+	gathered := make(map[string]GoPkg)
+
+	out, err := runGoList(path)
+
+	if err != nil {
+		return nil, err
+	}
+
+	/* we cann't just marshall the json as go list returns multiple json
+	 * documents not an array of json - which is annoying
+	 */
+	decoder := json.NewDecoder(strings.NewReader(string(out)))
+
+	for {
+		var goListDeps GoListDeps
+		err := decoder.Decode(&goListDeps)
+		if err == io.EOF {
+			break
+		}
 		if err != nil {
 			return nil, err
 		}
-	}
 
-	// based off the original https://github.com/golang/tools/blob/e140590b16906206021525faa5a48c7314806569/go/packages/gopackages/main.go#L99
-	// todo: should just get this put into the go/packages repo instead
-	var all []*packages.Package // postorder
-	seen := make(map[*packages.Package]bool)
+		importPath := goListDeps.ImportPath
 
-	var visit func(*packages.Package)
-	visit = func(lpkg *packages.Package) {
-		if !seen[lpkg] {
-			seen[lpkg] = true
-
-			// visit imports
-			var importPaths []string
-			for path := range lpkg.Imports {
-				importPaths = append(importPaths, path)
+		if _, ok := gathered[importPath]; ok {
+			if gathered[importPath].Version != semver.Max(gathered[importPath].Version, getVersion(goListDeps)) {
+				gathered[importPath] = GoPkg{
+					Version: getVersion(goListDeps),
+					Gofiles: goListDeps.GoFiles,
+				}
 			}
-			sort.Strings(importPaths) // for determinism
-			for _, path := range importPaths {
-				visit(lpkg.Imports[path])
+		} else {
+			gathered[importPath] = GoPkg{
+				Version: getVersion(goListDeps),
+				Gofiles: goListDeps.GoFiles,
 			}
-
-			all = append(all, lpkg)
 		}
 	}
-
-	for _, pkg := range pkgs {
-		visit(pkg)
-	}
-	pkgs = all
-
-	return pkgs, nil
+	return gathered, nil
 }

--- a/internal/scan/maven.go
+++ b/internal/scan/maven.go
@@ -41,11 +41,8 @@ func GetMvnDeps(path string) (map[string]string, error) {
 	cmd := exec.Command("mvn", "--no-transfer-progress", "dependency:tree", "-DoutputType=dot")
 	cmd.Dir = dirPath
 
-	data, err := cmd.Output()
-
-	if err != nil {
-		fmt.Println(err)
-	}
+	// supress error, it always returns errors
+	data, _ := cmd.Output()
 
 	res := strings.Split(string(data), "\n")
 


### PR DESCRIPTION
Due to issues calling packages.Load change instead to calling the external process `go list` instead. 

Then adding in a timeout to force the process to close if it runs for a generous 5 minutes.  Tested and working as expected so far.